### PR TITLE
DEV-411 [FIX] Ensures Record container takes its parent widget width.

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -8,15 +8,19 @@ fl-record-container .record-container-test-mode {
 
 fl-record {
   position: relative;
+  word-break: break-word;
+  display: block;
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 .mode-interact .fl-view-empty {
-  border: none!important;
-  color: #6A6868!important;
+  border: none !important;
+  color: #6a6868 !important;
   font-family: "Open Sans", sans-serif;
   font-size: 12px;
   padding: 15px;
   text-align: center;
-  padding: 0!important;
-  display: block!important;
+  padding: 0 !important;
+  display: block !important;
 }


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Record Container

### What does this PR do?

Ensures Record container takes its parent widget width.

### JIRA tickets

[DEV-411](https://weboo.atlassian.net/browse/DEV-411)

[DEV-411]: https://weboo.atlassian.net/browse/DEV-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved text wrapping and display for `fl-record` elements to ensure better readability and layout.
  * Enhanced consistency in CSS formatting for empty view styles in interactive mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->