### PR TITLE
Fix/DEV-250: Ensures Data record updates its value when opened from Data list.

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -297,15 +297,15 @@
       for (const deletedId of this.pendingUpdates.deleted) {
         if (deletedId === this.entry.id) {
           if (this.parent && typeof this.parent.connection === 'function') {
-              if (this.subscription && typeof this.subscription.unsubscribe === 'function') {
-              this.subscription.unsubscribe();
-              }
+            if (this.subscription && typeof this.subscription.unsubscribe === 'function') {
+            this.subscription.unsubscribe();
+            }
 
-              if (!isInteract && Fliplet && Fliplet.Navigate && typeof Fliplet.Navigate.back === 'function') {
-                Fliplet.Navigate.back();
-              }
+            if (!isInteract && Fliplet && Fliplet.Navigate && typeof Fliplet.Navigate.back === 'function') {
+              Fliplet.Navigate.back();
+            }
 
-              this.setupDataSubscription(connection);
+            this.setupDataSubscription(connection);
           }
         }
       }

--- a/js/build.js
+++ b/js/build.js
@@ -255,14 +255,14 @@
 
     onDelete(deletions = []) {
       deletions.forEach(deletion => {
-        const updatedIndex = this.pendingUpdates.updated.findIndex(row => row.id === deletion);
+        const updatedIndex = this.pendingUpdates.updated.findIndex(row => row.id === deletion.id);
 
         if (updatedIndex !== -1) {
           this.pendingUpdates.updated.splice(updatedIndex, 1);
         }
 
-        if (!this.pendingUpdates.deleted.includes(deletion)) {
-          this.pendingUpdates.deleted.push(deletion);
+        if (!this.pendingUpdates.deleted.includes(deletion.id)) {
+          this.pendingUpdates.deleted.push(deletion.id);
         }
 
         const deletedEntriesKey = `deleted-entries-${this.dataSourceId}`;

--- a/js/build.js
+++ b/js/build.js
@@ -31,6 +31,7 @@
       };
       this.recordTemplatePaths = [];
       this.testDataObject = {};
+      this.dataSourceId = undefined;
 
       this.init();
     }
@@ -100,25 +101,9 @@
         } else if (this.parent && typeof this.parent.connection === 'function') {
           const connection = await this.parent.connection();
           const dataSourceEntryId = Fliplet.Navigate.query.dataSourceEntryId;
+          this.dataSourceId = connection.id;
 
-          const hookResult = await Fliplet.Hooks.run('recordContainerBeforeRetrieveData', {
-            container: this.element,
-            connection: connection,
-            instance: this,
-            dataSourceId: connection.id,
-            dataSourceEntryId
-          });
-
-          const query = Object.assign({}, ...hookResult);
-
-          if (Object.keys(query).length) {
-            this.entry = await connection.findOne(query);
-          } else if (dataSourceEntryId) {
-            this.entry = await connection.findById(dataSourceEntryId);
-          } else if (this.testMode) {
-            this.entry = await connection.findOne();
-          }
-
+          await this.retrieveEntryData(connection, dataSourceEntryId);
           if (this.entry && ['informed', 'live'].includes(this.data.updateType)) {
             this.setupDataSubscription(connection);
           }
@@ -146,7 +131,10 @@
     }
 
     setupDataSubscription(connection) {
-      const events = ['update'];
+      if (this.subscription) {
+        this.subscription.unsubscribe();
+      }
+      const events = ['update', 'delete'];
 
       this.subscription = connection.subscribe(
         { id: this.entry.id, events },
@@ -267,30 +255,61 @@
 
     onDelete(deletions = []) {
       deletions.forEach(deletion => {
-        const updatedIndex = this.pendingUpdates.updated.findIndex(row => row.id === deletion.id);
+        const updatedIndex = this.pendingUpdates.updated.findIndex(row => row.id === deletion);
 
         if (updatedIndex !== -1) {
           this.pendingUpdates.updated.splice(updatedIndex, 1);
         }
 
-        if (!this.pendingUpdates.deleted.includes(deletion.id)) {
-          this.pendingUpdates.deleted.push(deletion.id);
+        if (!this.pendingUpdates.deleted.includes(deletion)) {
+          this.pendingUpdates.deleted.push(deletion);
         }
+
+        const deletedEntriesKey = `deleted-entries-${this.dataSourceId}`;
+        localStorage.removeItem(deletedEntriesKey);
       });
     }
 
-    applyUpdates() {
+    async retrieveEntryData(connection, dataSourceEntryId) {
+      const hookResult = await Fliplet.Hooks.run('recordContainerBeforeRetrieveData', {
+        container: this.element,
+        connection: connection,
+        instance: this,
+        dataSourceId: connection.id,
+        dataSourceEntryId
+      });
+
+      const query = Object.assign({}, ...hookResult);
+
+      if (Object.keys(query).length) {
+        this.entry = await connection.findOne(query);
+      } else if (dataSourceEntryId) {
+        this.entry = await connection.findById(dataSourceEntryId);
+      } else if (this.testMode) {
+        this.entry = await connection.findOne();
+      }
+    }
+
+    async applyUpdates() {
       this.pendingUpdates.updated.forEach(update => {
         if (update.id === this.entry.id) {
           this.entry = update;
         }
       });
 
-      this.pendingUpdates.deleted.forEach(deletedId => {
+      for (const deletedId of this.pendingUpdates.deleted) {
         if (deletedId === this.entry.id) {
-          this.entry = undefined;
+          if (this.parent && typeof this.parent.connection === 'function') {
+            const connection = await this.parent.connection();
+            const dataSourceEntryId = Fliplet.Navigate.query.dataSourceEntryId;
+
+            await this.retrieveEntryData(connection, dataSourceEntryId);
+
+            this.subscription.unsubscribe();
+            this.setupDataSubscription(connection);
+          }
         }
-      });
+      }
 
       this.pendingUpdates = {
         updated: [],

--- a/js/build.js
+++ b/js/build.js
@@ -300,13 +300,15 @@
       for (const deletedId of this.pendingUpdates.deleted) {
         if (deletedId === this.entry.id) {
           if (this.parent && typeof this.parent.connection === 'function') {
-            const connection = await this.parent.connection();
-            const dataSourceEntryId = Fliplet.Navigate.query.dataSourceEntryId;
+              if (this.subscription && typeof this.subscription.unsubscribe === 'function') {
+              this.subscription.unsubscribe();
+              }
 
-            await this.retrieveEntryData(connection, dataSourceEntryId);
+              if (!isInteract && Fliplet && Fliplet.Navigate && typeof Fliplet.Navigate.back === 'function') {
+                Fliplet.Navigate.back();
+              }
 
-            this.subscription.unsubscribe();
-            this.setupDataSubscription(connection);
+              this.setupDataSubscription(connection);
           }
         }
       }


### PR DESCRIPTION
### Product areas affected

Fliplet Widget Record Container

### What does this PR do?

Ensures Data record updates its value when opened from Data list.

### JIRA ticket

[DEV-250](https://weboo.atlassian.net/browse/DEV-250)

[DEV-594]: https://weboo.atlassian.net/browse/DEV-594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DEV-250]: https://weboo.atlassian.net/browse/DEV-250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatically returns to the previous screen after deleting an item when not in interactive mode.

- Bug Fixes
  - Safely cleans up active data subscriptions on delete to prevent duplicate updates and potential memory issues.

- Refactor
  - Simplified post-delete update flow to rely on live data subscriptions rather than extra one-off retrievals, improving responsiveness and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->